### PR TITLE
Add AWS Bedrock Guardrails support

### DIFF
--- a/lib/ruby_llm/configuration.rb
+++ b/lib/ruby_llm/configuration.rb
@@ -20,6 +20,8 @@ module RubyLLM
                   :bedrock_secret_key,
                   :bedrock_region,
                   :bedrock_session_token,
+                  :bedrock_guardrail_identifier,
+                  :bedrock_guardrail_version,
                   :openrouter_api_key,
                   :ollama_api_base,
                   :gpustack_api_base,

--- a/lib/ruby_llm/providers/bedrock.rb
+++ b/lib/ruby_llm/providers/bedrock.rb
@@ -68,6 +68,19 @@ module RubyLLM
         )
       end
 
+      def build_guardrail_headers
+        headers = {}
+        guardrail_id = @config.bedrock_guardrail_identifier
+        guardrail_version = @config.bedrock_guardrail_version || 'DRAFT'
+
+        if guardrail_id && !guardrail_id.to_s.strip.empty?
+          headers['X-Amzn-Bedrock-GuardrailIdentifier'] = guardrail_id
+          headers['X-Amzn-Bedrock-GuardrailVersion'] = guardrail_version
+          Rails.logger.info "[GUARDRAILS] Adding headers: #{headers.inspect}" if defined?(Rails)
+        end
+        headers
+      end
+
       class << self
         def capabilities
           Bedrock::Capabilities

--- a/lib/ruby_llm/providers/bedrock/chat.rb
+++ b/lib/ruby_llm/providers/bedrock/chat.rb
@@ -9,8 +9,10 @@ module RubyLLM
 
         def sync_response(connection, payload, additional_headers = {})
           signature = sign_request("#{connection.connection.url_prefix}#{completion_url}", payload:)
+          guardrail_headers = build_guardrail_headers
           response = connection.post completion_url, payload do |req|
             req.headers.merge! build_headers(signature.headers, streaming: block_given?)
+            req.headers.merge!(guardrail_headers) # Add guardrails AFTER signing
             req.headers = additional_headers.merge(req.headers) unless additional_headers.empty?
           end
           Anthropic::Chat.parse_completion_response response

--- a/lib/ruby_llm/providers/bedrock/streaming/base.rb
+++ b/lib/ruby_llm/providers/bedrock/streaming/base.rb
@@ -20,9 +20,11 @@ module RubyLLM
           def stream_response(connection, payload, additional_headers = {}, &block)
             signature = sign_request("#{connection.connection.url_prefix}#{stream_url}", payload:)
             accumulator = StreamAccumulator.new
+            guardrail_headers = build_guardrail_headers
 
             response = connection.post stream_url, payload do |req|
               req.headers.merge! build_headers(signature.headers, streaming: block_given?)
+              req.headers.merge!(guardrail_headers) # Add guardrails AFTER signing
               # Merge additional headers, with existing headers taking precedence
               req.headers = additional_headers.merge(req.headers) unless additional_headers.empty?
               req.options.on_data = handle_stream do |chunk|

--- a/spec/ruby_llm/providers/bedrock_guardrails_spec.rb
+++ b/spec/ruby_llm/providers/bedrock_guardrails_spec.rb
@@ -2,8 +2,6 @@
 
 RSpec.describe RubyLLM::Providers::Bedrock do
   describe '#build_guardrail_headers' do
-    let(:provider) { described_class.new }
-
     before do
       RubyLLM.configure do |config|
         config.bedrock_api_key = 'test-key'
@@ -18,6 +16,8 @@ RSpec.describe RubyLLM::Providers::Bedrock do
         config.bedrock_guardrail_version = nil
       end
     end
+
+    let(:provider) { described_class.new(RubyLLM.config) }
 
     context 'when guardrail identifier is configured' do
       before do

--- a/spec/ruby_llm/providers/bedrock_guardrails_spec.rb
+++ b/spec/ruby_llm/providers/bedrock_guardrails_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe RubyLLM::Providers::Bedrock do
+  describe '#build_guardrail_headers' do
+    let(:provider) { described_class.new }
+
+    before do
+      RubyLLM.configure do |config|
+        config.bedrock_api_key = 'test-key'
+        config.bedrock_secret_key = 'test-secret'
+        config.bedrock_region = 'us-west-2'
+      end
+    end
+
+    after do
+      RubyLLM.configure do |config|
+        config.bedrock_guardrail_identifier = nil
+        config.bedrock_guardrail_version = nil
+      end
+    end
+
+    context 'when guardrail identifier is configured' do
+      before do
+        RubyLLM.configure do |config|
+          config.bedrock_guardrail_identifier = 'abc123'
+          config.bedrock_guardrail_version = '3'
+        end
+      end
+
+      it 'returns headers with guardrail identifier and version' do
+        headers = provider.build_guardrail_headers
+        expect(headers).to eq(
+          'X-Amzn-Bedrock-GuardrailIdentifier' => 'abc123',
+          'X-Amzn-Bedrock-GuardrailVersion' => '3'
+        )
+      end
+    end
+
+    context 'when guardrail identifier is configured without version' do
+      before do
+        RubyLLM.configure do |config|
+          config.bedrock_guardrail_identifier = 'abc123'
+          config.bedrock_guardrail_version = nil
+        end
+      end
+
+      it 'defaults version to DRAFT' do
+        headers = provider.build_guardrail_headers
+        expect(headers).to eq(
+          'X-Amzn-Bedrock-GuardrailIdentifier' => 'abc123',
+          'X-Amzn-Bedrock-GuardrailVersion' => 'DRAFT'
+        )
+      end
+    end
+
+    context 'when guardrail identifier is not configured' do
+      before do
+        RubyLLM.configure do |config|
+          config.bedrock_guardrail_identifier = nil
+          config.bedrock_guardrail_version = nil
+        end
+      end
+
+      it 'returns empty headers' do
+        headers = provider.build_guardrail_headers
+        expect(headers).to eq({})
+      end
+    end
+
+    context 'when guardrail identifier is an empty string' do
+      before do
+        RubyLLM.configure do |config|
+          config.bedrock_guardrail_identifier = ''
+          config.bedrock_guardrail_version = '2'
+        end
+      end
+
+      it 'returns empty headers' do
+        headers = provider.build_guardrail_headers
+        expect(headers).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this does

Adds AWS Bedrock Guardrails support by injecting guardrail headers (`X-Amzn-Bedrock-GuardrailIdentifier` and `X-Amzn-Bedrock-GuardrailVersion`) into Bedrock API requests. Headers are applied **after** AWS request signing to avoid invalidating the signature.

## Configuration

```ruby
RubyLLM.configure do |config|
  config.bedrock_guardrail_identifier = ENV.fetch('BEDROCK_GUARDRAIL_ID', nil)
  config.bedrock_guardrail_version = ENV.fetch('BEDROCK_GUARDRAIL_VERSION', 'DRAFT')
end
```

When `bedrock_guardrail_identifier` is set, every Bedrock request (sync and streaming) includes the guardrail headers. When not set, behavior is unchanged — no headers are added.

## Changes

| File | Change |
|------|--------|
| `lib/ruby_llm/configuration.rb` | Added `bedrock_guardrail_identifier` and `bedrock_guardrail_version` config attrs |
| `lib/ruby_llm/providers/bedrock.rb` | Added `build_guardrail_headers` method |
| `lib/ruby_llm/providers/bedrock/chat.rb` | Inject guardrail headers after signing in sync path |
| `lib/ruby_llm/providers/bedrock/streaming/base.rb` | Inject guardrail headers after signing in streaming path |

## How Bedrock Guardrails work

AWS Bedrock Guardrails evaluate both input and output against configured content policies (denied topics, content filters, word filters). When a guardrail intervenes, the response includes `\"amazon-bedrock-guardrailAction\": \"GUARDRAIL_INTERVENED\"` and the model output is replaced with the guardrail's configured block message.

The guardrail headers must be added **after** AWS request signing because they are not part of the signed request — including them in signing would invalidate the signature.